### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/walkmod/javalang/ASTManager.java
+++ b/src/main/java/org/walkmod/javalang/ASTManager.java
@@ -291,7 +291,7 @@ public class ASTManager {
 					throw new ParseException("The " + clazz.getSimpleName()
 							+ " cannot be parseable");
 				} catch (InvocationTargetException e) {
-					throw (ParseException) (e.getTargetException());
+					throw (ParseException) e.getTargetException();
 				}
 			} finally {
 				sr.close();

--- a/src/main/java/org/walkmod/javalang/ASTParser.java
+++ b/src/main/java/org/walkmod/javalang/ASTParser.java
@@ -115,7 +115,7 @@ final class ASTParser implements ASTParserConstants {
    }
 
    public int addModifier(int modifiers, int mod, Token token) throws ParseException {
-      if ((ModifierSet.hasModifier(modifiers, mod))) {
+      if (ModifierSet.hasModifier(modifiers, mod)) {
          throwParseException(token, "Duplicated modifier");
       }
       return ModifierSet.addModifier(modifiers, mod);
@@ -184,7 +184,7 @@ final class ASTParser implements ASTParserConstants {
          ;
       }
       label_1: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case IMPORT:
             ;
             break;
@@ -200,7 +200,7 @@ final class ASTParser implements ASTParserConstants {
          imports = add(imports, in);
       }
       label_2: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case CLASS:
          case ENUM:
@@ -230,7 +230,7 @@ final class ASTParser implements ASTParserConstants {
          }
          types = add(types, tn);
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case 0:
          jj_consume_token(0);
          break;
@@ -257,7 +257,7 @@ final class ASTParser implements ASTParserConstants {
       int line;
       int column;
       label_3: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -289,7 +289,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(IMPORT);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case STATIC:
          jj_consume_token(STATIC);
          isStatic = true;
@@ -299,7 +299,7 @@ final class ASTParser implements ASTParserConstants {
          ;
       }
       name = Name();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case DOT:
          jj_consume_token(DOT);
          jj_consume_token(STAR);
@@ -334,7 +334,7 @@ final class ASTParser implements ASTParserConstants {
          } else {
             break label_4;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PUBLIC:
             jj_consume_token(PUBLIC);
             modifiers = addModifier(modifiers, ModifierSet.PUBLIC, token);
@@ -451,7 +451,7 @@ final class ASTParser implements ASTParserConstants {
       Modifier modifier;
       TypeDeclaration ret;
       pushJavadoc();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case SEMICOLON:
          jj_consume_token(SEMICOLON);
          ret = new EmptyTypeDeclaration(token.beginLine, token.beginColumn, token.endLine, token.endColumn,
@@ -473,7 +473,7 @@ final class ASTParser implements ASTParserConstants {
       case VOLATILE:
       case AT:
          modifier = Modifiers();
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case CLASS:
          case INTERFACE:
             ret = ClassOrInterfaceDeclaration(modifier);
@@ -511,7 +511,7 @@ final class ASTParser implements ASTParserConstants {
       List members;
       int line = modifier.beginLine;
       int column = modifier.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case CLASS:
          jj_consume_token(CLASS);
          break;
@@ -530,7 +530,7 @@ final class ASTParser implements ASTParserConstants {
       }
       jj_consume_token(IDENTIFIER);
       name = token.image;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LT:
          typePar = TypeParameters();
          typePar.remove(0);
@@ -539,7 +539,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[10] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case EXTENDS:
          extList = ExtendsList(isInterface);
          break;
@@ -547,7 +547,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[11] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IMPLEMENTS:
          impList = ImplementsList(isInterface);
          break;
@@ -572,7 +572,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       jj_consume_token(EXTENDS);
       label_5: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -587,7 +587,7 @@ final class ASTParser implements ASTParserConstants {
       cit.setAnnotations(annotations);
       ret.add(cit);
       label_6: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -616,7 +616,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       jj_consume_token(IMPLEMENTS);
       label_7: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -631,7 +631,7 @@ final class ASTParser implements ASTParserConstants {
       cit.setAnnotations(annotations);
       ret.add(cit);
       label_8: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -668,7 +668,7 @@ final class ASTParser implements ASTParserConstants {
       }
       jj_consume_token(IDENTIFIER);
       name = token.image;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IMPLEMENTS:
          impList = ImplementsList(false);
          break;
@@ -677,7 +677,7 @@ final class ASTParser implements ASTParserConstants {
          ;
       }
       jj_consume_token(LBRACE);
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IDENTIFIER:
       case AT:
          entries = new LinkedList();
@@ -698,7 +698,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[18] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case COMMA:
          jj_consume_token(COMMA);
          break;
@@ -706,11 +706,11 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[19] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case SEMICOLON:
          jj_consume_token(SEMICOLON);
          label_10: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case ABSTRACT:
             case BOOLEAN:
             case BYTE:
@@ -773,7 +773,7 @@ final class ASTParser implements ASTParserConstants {
       int column = -1;
       pushJavadoc();
       label_11: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -794,7 +794,7 @@ final class ASTParser implements ASTParserConstants {
          line = token.beginLine;
          column = token.beginColumn;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LPAREN:
          args = Arguments();
          break;
@@ -802,7 +802,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[23] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LBRACE:
          classBody = ClassOrInterfaceBody(false);
          break;
@@ -826,7 +826,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(LT);
       ret.add(new int[] { token.beginLine, token.beginColumn });
       label_12: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -842,7 +842,7 @@ final class ASTParser implements ASTParserConstants {
       tp.setAnnotations(annotations);
       annotations = null;
       label_13: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -852,7 +852,7 @@ final class ASTParser implements ASTParserConstants {
          }
          jj_consume_token(COMMA);
          label_14: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case AT:
                ;
                break;
@@ -885,7 +885,7 @@ final class ASTParser implements ASTParserConstants {
       name = token.image;
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case EXTENDS:
          typeBound = TypeBound();
          break;
@@ -907,7 +907,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       jj_consume_token(EXTENDS);
       label_15: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -923,7 +923,7 @@ final class ASTParser implements ASTParserConstants {
       ret.add(cit);
       annotations = null;
       label_16: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BIT_AND:
             ;
             break;
@@ -933,7 +933,7 @@ final class ASTParser implements ASTParserConstants {
          }
          jj_consume_token(BIT_AND);
          label_17: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case AT:
                ;
                break;
@@ -961,7 +961,7 @@ final class ASTParser implements ASTParserConstants {
       BodyDeclaration member;
       jj_consume_token(LBRACE);
       label_18: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case BOOLEAN:
          case BYTE:
@@ -1021,7 +1021,7 @@ final class ASTParser implements ASTParserConstants {
          if (isInterface)
             throwParseException(token, "An interface cannot have initializers");
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case BOOLEAN:
          case BYTE:
@@ -1050,7 +1050,7 @@ final class ASTParser implements ASTParserConstants {
          case AT:
          case LT:
             modifier = Modifiers();
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case _DEFAULT:
                jj_consume_token(_DEFAULT);
                modifier2 = Modifiers();
@@ -1063,7 +1063,7 @@ final class ASTParser implements ASTParserConstants {
                jj_la1[33] = jj_gen;
                ;
             }
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case CLASS:
             case INTERFACE:
                ret = ClassOrInterfaceDeclaration(modifier);
@@ -1081,7 +1081,7 @@ final class ASTParser implements ASTParserConstants {
                } else if (jj_2_5(2147483647)) {
                   ret = FieldDeclaration(modifier);
                } else {
-                  switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                  switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                   case BOOLEAN:
                   case BYTE:
                   case CHAR:
@@ -1141,7 +1141,7 @@ final class ASTParser implements ASTParserConstants {
       val = VariableDeclarator();
       variables.add(val);
       label_19: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -1172,7 +1172,7 @@ final class ASTParser implements ASTParserConstants {
       VariableDeclaratorId id;
       Expression init = null;
       id = VariableDeclaratorId();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case ASSIGN:
          jj_consume_token(ASSIGN);
          init = VariableInitializer();
@@ -1199,7 +1199,7 @@ final class ASTParser implements ASTParserConstants {
       line = token.beginLine;
       column = token.beginColumn;
       label_20: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LBRACKET:
             ;
             break;
@@ -1220,7 +1220,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public Expression VariableInitializer() throws ParseException {
       Expression ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LBRACE:
          ret = ArrayInitializer();
          break;
@@ -1274,7 +1274,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(LBRACE);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -1321,7 +1321,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[41] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case COMMA:
          jj_consume_token(COMMA);
          break;
@@ -1347,7 +1347,7 @@ final class ASTParser implements ASTParserConstants {
       BlockStmt block = null;
       int line = modifier.beginLine;
       int column = modifier.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LT:
          typeParameters = TypeParameters();
          int[] lineCol = (int[]) typeParameters.remove(0);
@@ -1369,7 +1369,7 @@ final class ASTParser implements ASTParserConstants {
       name = token.image;
       parameters = FormalParameters();
       label_22: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LBRACKET:
             ;
             break;
@@ -1381,7 +1381,7 @@ final class ASTParser implements ASTParserConstants {
          jj_consume_token(RBRACKET);
          arrayCount++;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case THROWS:
          jj_consume_token(THROWS);
          throws_ = ClassOrInterfaceTypeList();
@@ -1390,7 +1390,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[45] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LBRACE:
          block = Block();
          break;
@@ -1415,7 +1415,7 @@ final class ASTParser implements ASTParserConstants {
       List ret = null;
       Parameter par;
       jj_consume_token(LPAREN);
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case ABSTRACT:
       case BOOLEAN:
       case BYTE:
@@ -1440,7 +1440,7 @@ final class ASTParser implements ASTParserConstants {
          par = FormalParameter();
          ret = add(ret, par);
          label_23: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case COMMA:
                ;
                break;
@@ -1472,7 +1472,7 @@ final class ASTParser implements ASTParserConstants {
       par = FormalParameter();
       ret = add(ret, par);
       label_24: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -1499,7 +1499,7 @@ final class ASTParser implements ASTParserConstants {
       ret = add(ret, new Parameter(id.getBeginLine(), id.getBeginColumn(), id.getEndLine(), id.getEndColumn(), 0, null,
             null, false, id));
       label_25: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -1526,7 +1526,7 @@ final class ASTParser implements ASTParserConstants {
       VariableDeclaratorId id;
       modifier = Modifiers();
       type = Type();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case ELLIPSIS:
          jj_consume_token(ELLIPSIS);
          isVarArg = true;
@@ -1563,7 +1563,7 @@ final class ASTParser implements ASTParserConstants {
       int bbColumn = 0;
       int beLine = 0;
       int beColumn = 0;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LT:
          typeParameters = TypeParameters();
          int[] lineCol = (int[]) typeParameters.remove(0);
@@ -1583,7 +1583,7 @@ final class ASTParser implements ASTParserConstants {
          column = token.beginColumn;
       }
       parameters = FormalParameters();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case THROWS:
          jj_consume_token(THROWS);
          throws_ = ClassOrInterfaceTypeList();
@@ -1622,7 +1622,7 @@ final class ASTParser implements ASTParserConstants {
       int line = -1;
       int column = 0;
       if (jj_2_10(2147483647)) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LT:
          case 132:
             typeArgs = TypeArguments();
@@ -1643,7 +1643,7 @@ final class ASTParser implements ASTParserConstants {
          args = Arguments();
          jj_consume_token(SEMICOLON);
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BOOLEAN:
          case BYTE:
          case CHAR:
@@ -1676,7 +1676,7 @@ final class ASTParser implements ASTParserConstants {
             } else {
                ;
             }
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case LT:
             case 132:
                typeArgs = TypeArguments();
@@ -1716,7 +1716,7 @@ final class ASTParser implements ASTParserConstants {
       List ret = null;
       Statement stmt;
       label_26: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case ASSERT:
          case BOOLEAN:
@@ -1789,7 +1789,7 @@ final class ASTParser implements ASTParserConstants {
       int line = -1;
       int column = 0;
       boolean isStatic = false;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case STATIC:
          jj_consume_token(STATIC);
          isStatic = true;
@@ -1821,7 +1821,7 @@ final class ASTParser implements ASTParserConstants {
       if (jj_2_11(2)) {
          ret = ReferenceType();
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BOOLEAN:
          case BYTE:
          case CHAR:
@@ -1851,7 +1851,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       List accum = null;
       AnnotationExpr ann;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -1863,7 +1863,7 @@ final class ASTParser implements ASTParserConstants {
          type = PrimitiveType();
          label_27: while (true) {
             label_28: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case AT:
                   ;
                   break;
@@ -1895,7 +1895,7 @@ final class ASTParser implements ASTParserConstants {
                break label_29;
             }
             label_30: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case AT:
                   ;
                   break;
@@ -1954,7 +1954,7 @@ final class ASTParser implements ASTParserConstants {
          }
          jj_consume_token(DOT);
          label_32: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case AT:
                ;
                break;
@@ -1988,14 +1988,14 @@ final class ASTParser implements ASTParserConstants {
    final public List TypeArguments() throws ParseException {
       List ret = new LinkedList();
       Type type;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LT:
          jj_consume_token(LT);
          ret.add(new int[] { token.beginLine, token.beginColumn });
          type = TypeArgument();
          ret.add(type);
          label_33: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case COMMA:
                ;
                break;
@@ -2034,7 +2034,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       AnnotationExpr ann;
       label_34: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -2045,7 +2045,7 @@ final class ASTParser implements ASTParserConstants {
          ann = Annotation();
          annotations = add(annotations, ann);
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -2083,14 +2083,14 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(HOOK);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case EXTENDS:
       case SUPER:
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case EXTENDS:
             jj_consume_token(EXTENDS);
             label_35: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case AT:
                   ;
                   break;
@@ -2107,7 +2107,7 @@ final class ASTParser implements ASTParserConstants {
          case SUPER:
             jj_consume_token(SUPER);
             label_36: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case AT:
                   ;
                   break;
@@ -2140,7 +2140,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public PrimitiveType PrimitiveType() throws ParseException {
       PrimitiveType ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
          jj_consume_token(BOOLEAN);
          ret = new PrimitiveType(token.beginLine, token.beginColumn, token.endLine, token.endColumn,
@@ -2195,7 +2195,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public Type ResultType() throws ParseException {
       Type ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case VOID:
          jj_consume_token(VOID);
          ret = new VoidType(token.beginLine, token.beginColumn, token.endLine, token.endColumn);
@@ -2251,7 +2251,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       AnnotationExpr ann;
       label_38: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -2267,7 +2267,7 @@ final class ASTParser implements ASTParserConstants {
       ret.add(type);
       annotations = null;
       label_39: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -2277,7 +2277,7 @@ final class ASTParser implements ASTParserConstants {
          }
          jj_consume_token(COMMA);
          label_40: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case AT:
                ;
                break;
@@ -2313,7 +2313,7 @@ final class ASTParser implements ASTParserConstants {
       VariableDeclaratorId id = null;
       Expression inner = null;
       ret = ConditionalExpression();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case ASSIGN:
       case PLUSASSIGN:
       case MINUSASSIGN:
@@ -2334,7 +2334,7 @@ final class ASTParser implements ASTParserConstants {
             ret = new AssignExpr(ret.getBeginLine(), ret.getBeginColumn(), token.endLine, token.endColumn, ret, value,
                   op);
          } else {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case ARROW:
                jj_consume_token(ARROW);
                lambdaBody = LambdaBody();
@@ -2352,7 +2352,7 @@ final class ASTParser implements ASTParserConstants {
                break;
             case DOUBLECOLON:
                jj_consume_token(DOUBLECOLON);
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LT:
                   typeArgs = TypeParameters();
                   typeArgs.remove(0);
@@ -2361,7 +2361,7 @@ final class ASTParser implements ASTParserConstants {
                   jj_la1[77] = jj_gen;
                   ;
                }
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case IDENTIFIER:
                   jj_consume_token(IDENTIFIER);
                   break;
@@ -2396,7 +2396,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public AssignExpr.Operator AssignmentOperator() throws ParseException {
       AssignExpr.Operator ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case ASSIGN:
          jj_consume_token(ASSIGN);
          ret = AssignExpr.Operator.assign;
@@ -2462,7 +2462,7 @@ final class ASTParser implements ASTParserConstants {
       Expression left;
       Expression right;
       ret = ConditionalOrExpression();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case HOOK:
          jj_consume_token(HOOK);
          left = Expression();
@@ -2487,7 +2487,7 @@ final class ASTParser implements ASTParserConstants {
       Expression right;
       ret = ConditionalAndExpression();
       label_41: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case SC_OR:
             ;
             break;
@@ -2512,7 +2512,7 @@ final class ASTParser implements ASTParserConstants {
       Expression right;
       ret = InclusiveOrExpression();
       label_42: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case SC_AND:
             ;
             break;
@@ -2537,7 +2537,7 @@ final class ASTParser implements ASTParserConstants {
       Expression right;
       ret = ExclusiveOrExpression();
       label_43: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BIT_OR:
             ;
             break;
@@ -2562,7 +2562,7 @@ final class ASTParser implements ASTParserConstants {
       Expression right;
       ret = AndExpression();
       label_44: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case XOR:
             ;
             break;
@@ -2587,7 +2587,7 @@ final class ASTParser implements ASTParserConstants {
       Expression right;
       ret = EqualityExpression();
       label_45: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BIT_AND:
             ;
             break;
@@ -2613,7 +2613,7 @@ final class ASTParser implements ASTParserConstants {
       BinaryExpr.Operator op;
       ret = InstanceOfExpression();
       label_46: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case EQ:
          case NE:
             ;
@@ -2622,7 +2622,7 @@ final class ASTParser implements ASTParserConstants {
             jj_la1[88] = jj_gen;
             break label_46;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case EQ:
             jj_consume_token(EQ);
             op = BinaryExpr.Operator.equals;
@@ -2650,7 +2650,7 @@ final class ASTParser implements ASTParserConstants {
       Expression ret;
       Type type;
       ret = RelationalExpression();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case INSTANCEOF:
          jj_consume_token(INSTANCEOF);
          type = Type();
@@ -2673,7 +2673,7 @@ final class ASTParser implements ASTParserConstants {
       BinaryExpr.Operator op;
       ret = ShiftExpression();
       label_47: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LT:
          case LE:
          case GE:
@@ -2684,7 +2684,7 @@ final class ASTParser implements ASTParserConstants {
             jj_la1[91] = jj_gen;
             break label_47;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LT:
             jj_consume_token(LT);
             op = BinaryExpr.Operator.less;
@@ -2727,7 +2727,7 @@ final class ASTParser implements ASTParserConstants {
          } else {
             break label_48;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LSHIFT:
             jj_consume_token(LSHIFT);
             op = BinaryExpr.Operator.lShift;
@@ -2761,7 +2761,7 @@ final class ASTParser implements ASTParserConstants {
       BinaryExpr.Operator op;
       ret = MultiplicativeExpression();
       label_49: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PLUS:
          case MINUS:
             ;
@@ -2770,7 +2770,7 @@ final class ASTParser implements ASTParserConstants {
             jj_la1[94] = jj_gen;
             break label_49;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PLUS:
             jj_consume_token(PLUS);
             op = BinaryExpr.Operator.plus;
@@ -2800,7 +2800,7 @@ final class ASTParser implements ASTParserConstants {
       BinaryExpr.Operator op;
       ret = UnaryExpression();
       label_50: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case STAR:
          case SLASH:
          case REM:
@@ -2810,7 +2810,7 @@ final class ASTParser implements ASTParserConstants {
             jj_la1[96] = jj_gen;
             break label_50;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case STAR:
             jj_consume_token(STAR);
             op = BinaryExpr.Operator.times;
@@ -2843,7 +2843,7 @@ final class ASTParser implements ASTParserConstants {
       UnaryExpr.Operator op;
       int line = 0;
       int column = 0;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case INCR:
          ret = PreIncrementExpression();
          break;
@@ -2852,7 +2852,7 @@ final class ASTParser implements ASTParserConstants {
          break;
       case PLUS:
       case MINUS:
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PLUS:
             jj_consume_token(PLUS);
             op = UnaryExpr.Operator.positive;
@@ -2958,10 +2958,10 @@ final class ASTParser implements ASTParserConstants {
       UnaryExpr.Operator op;
       int line = 0;
       int column = 0;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BANG:
       case TILDE:
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case TILDE:
             jj_consume_token(TILDE);
             op = UnaryExpr.Operator.inverse;
@@ -2987,7 +2987,7 @@ final class ASTParser implements ASTParserConstants {
          if (jj_2_22(2147483647)) {
             ret = CastExpression();
          } else {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case BOOLEAN:
             case BYTE:
             case CHAR:
@@ -3031,7 +3031,7 @@ final class ASTParser implements ASTParserConstants {
       UnaryExpr.Operator op;
       ret = PrimaryExpression();
       if (jj_2_23(2)) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case INCR:
             jj_consume_token(INCR);
             op = UnaryExpr.Operator.posIncrement;
@@ -3069,7 +3069,7 @@ final class ASTParser implements ASTParserConstants {
       line = token.beginLine;
       column = token.beginColumn;
       label_51: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -3087,7 +3087,7 @@ final class ASTParser implements ASTParserConstants {
          type.setAnnotations(annotations);
          ret = new CastExpr(line, column, token.endLine, token.endColumn, type, ret);
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BOOLEAN:
          case BYTE:
          case CHAR:
@@ -3100,7 +3100,7 @@ final class ASTParser implements ASTParserConstants {
             type = ReferenceType();
             secondaryTypes = add(secondaryTypes, type);
             label_52: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case BIT_AND:
                   ;
                   break;
@@ -3184,7 +3184,7 @@ final class ASTParser implements ASTParserConstants {
       int column;
       Parameter p = null;
       VariableDeclaratorId id = null;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case FALSE:
       case NULL:
       case TRUE:
@@ -3202,10 +3202,10 @@ final class ASTParser implements ASTParserConstants {
       case SUPER:
          jj_consume_token(SUPER);
          ret = new SuperExpr(token.beginLine, token.beginColumn, token.endLine, token.endColumn, null);
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case DOT:
             jj_consume_token(DOT);
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case LT:
             case 132:
                typeArgs = TypeArguments();
@@ -3217,7 +3217,7 @@ final class ASTParser implements ASTParserConstants {
             }
             jj_consume_token(IDENTIFIER);
             name = token.image;
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case LPAREN:
                args = Arguments();
                hasArgs = true;
@@ -3232,7 +3232,7 @@ final class ASTParser implements ASTParserConstants {
             break;
          case DOUBLECOLON:
             jj_consume_token(DOUBLECOLON);
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case LT:
                typeArgs = TypeParameters();
                typeArgs.remove(0);
@@ -3241,7 +3241,7 @@ final class ASTParser implements ASTParserConstants {
                jj_la1[109] = jj_gen;
                ;
             }
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
                jj_consume_token(IDENTIFIER);
                break;
@@ -3271,7 +3271,7 @@ final class ASTParser implements ASTParserConstants {
          jj_consume_token(LPAREN);
          line = token.beginLine;
          column = token.beginColumn;
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case BOOLEAN:
          case BYTE:
@@ -3315,7 +3315,7 @@ final class ASTParser implements ASTParserConstants {
             if (jj_2_27(2147483647)) {
                p = FormalParameter();
                isLambda = true;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case COMMA:
                   args = FormalLambdaParameters();
                   break;
@@ -3324,7 +3324,7 @@ final class ASTParser implements ASTParserConstants {
                   ;
                }
             } else {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case BOOLEAN:
                case BYTE:
                case CHAR:
@@ -3354,7 +3354,7 @@ final class ASTParser implements ASTParserConstants {
                case PLUS:
                case MINUS:
                   ret = Expression();
-                  switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                  switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                   case COMMA:
                      args = InferredLambdaParameters();
                      isLambda = true;
@@ -3405,7 +3405,7 @@ final class ASTParser implements ASTParserConstants {
          } else if (jj_2_29(2147483647)) {
             type = ResultType();
             jj_consume_token(DOUBLECOLON);
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case LT:
                typeArgs = TypeParameters();
                typeArgs.remove(0);
@@ -3414,7 +3414,7 @@ final class ASTParser implements ASTParserConstants {
                jj_la1[116] = jj_gen;
                ;
             }
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
                jj_consume_token(IDENTIFIER);
                break;
@@ -3430,13 +3430,13 @@ final class ASTParser implements ASTParserConstants {
             ret = new MethodReferenceExpr(ret.getBeginLine(), ret.getBeginColumn(), token.endLine, token.endColumn,
                   ret, typeArgs, token.image);
          } else {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
                jj_consume_token(IDENTIFIER);
                name = token.image;
                line = token.beginLine;
                column = token.beginColumn;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LPAREN:
                   args = Arguments();
                   ret = new MethodCallExpr(line, column, token.endLine, token.endColumn, null, null, name, args);
@@ -3468,7 +3468,7 @@ final class ASTParser implements ASTParserConstants {
       if (jj_2_30(2)) {
          ret = PrimarySuffixWithoutSuper(scope);
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case DOT:
             jj_consume_token(DOT);
             jj_consume_token(SUPER);
@@ -3493,10 +3493,10 @@ final class ASTParser implements ASTParserConstants {
       List args = null;
       boolean hasArgs = false;
       String name;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case DOT:
          jj_consume_token(DOT);
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case THIS:
             jj_consume_token(THIS);
             ret = new ThisExpr(scope.getBeginLine(), scope.getBeginColumn(), token.endLine, token.endColumn, scope);
@@ -3507,7 +3507,7 @@ final class ASTParser implements ASTParserConstants {
          default:
             jj_la1[124] = jj_gen;
             if (jj_2_31(2147483647)) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LT:
                case 132:
                   typeArgs = TypeArguments();
@@ -3519,7 +3519,7 @@ final class ASTParser implements ASTParserConstants {
                }
                jj_consume_token(IDENTIFIER);
                name = token.image;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LPAREN:
                   args = Arguments();
                   hasArgs = true;
@@ -3558,7 +3558,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public Expression Literal() throws ParseException {
       Expression ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case INTEGER_LITERAL:
          jj_consume_token(INTEGER_LITERAL);
          ret = new IntegerLiteralExpr(token.beginLine, token.beginColumn, token.endLine, token.endColumn, token.image);
@@ -3602,7 +3602,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public Expression BooleanLiteral() throws ParseException {
       Expression ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case TRUE:
          jj_consume_token(TRUE);
          ret = new BooleanLiteralExpr(token.beginLine, token.beginColumn, token.endLine, token.endColumn, true);
@@ -3635,7 +3635,7 @@ final class ASTParser implements ASTParserConstants {
    final public List Arguments() throws ParseException {
       List ret = null;
       jj_consume_token(LPAREN);
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -3684,7 +3684,7 @@ final class ASTParser implements ASTParserConstants {
       expr = Expression();
       ret.add(expr);
       label_55: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -3724,7 +3724,7 @@ final class ASTParser implements ASTParserConstants {
          column = scope.getBeginColumn();
       }
       label_56: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -3735,7 +3735,7 @@ final class ASTParser implements ASTParserConstants {
          ann = Annotation();
          annotations = add(annotations, ann);
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -3761,12 +3761,12 @@ final class ASTParser implements ASTParserConstants {
       case IDENTIFIER:
       case LT:
       case 132:
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LT:
          case 132:
             typeArgs = TypeArguments();
             label_57: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case AT:
                   ;
                   break;
@@ -3784,7 +3784,7 @@ final class ASTParser implements ASTParserConstants {
             ;
          }
          type = ClassOrInterfaceType();
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LBRACKET:
          case AT:
             arr = ArrayDimsAndInits();
@@ -3842,7 +3842,7 @@ final class ASTParser implements ASTParserConstants {
       List annotations = null;
       AnnotationExpr ann;
       label_58: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ;
             break;
@@ -3874,7 +3874,7 @@ final class ASTParser implements ASTParserConstants {
                break label_60;
             }
             label_61: while (true) {
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case AT:
                   ;
                   break;
@@ -3894,13 +3894,13 @@ final class ASTParser implements ASTParserConstants {
          ret[0] = inits;
          ret[1] = new Integer(i);
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LBRACKET:
             label_62: while (true) {
                jj_consume_token(LBRACKET);
                jj_consume_token(RBRACKET);
                i++;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LBRACKET:
                   ;
                   break;
@@ -3937,7 +3937,7 @@ final class ASTParser implements ASTParserConstants {
       if (jj_2_36(2)) {
          ret = LabeledStatement();
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ASSERT:
             ret = AssertStatement();
             break;
@@ -4028,7 +4028,7 @@ final class ASTParser implements ASTParserConstants {
       line = token.beginLine;
       column = token.beginColumn;
       check = Expression();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case COLON:
          jj_consume_token(COLON);
          msg = Expression();
@@ -4098,7 +4098,7 @@ final class ASTParser implements ASTParserConstants {
          jj_consume_token(SEMICOLON);
          ret = new ExpressionStmt(expr.getBeginLine(), expr.getBeginColumn(), token.endLine, token.endColumn, expr);
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ASSERT:
          case BOOLEAN:
          case BREAK:
@@ -4162,7 +4162,7 @@ final class ASTParser implements ASTParserConstants {
       var = VariableDeclarator();
       vars.add(var);
       label_63: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -4200,7 +4200,7 @@ final class ASTParser implements ASTParserConstants {
    final public Statement LambdaBody() throws ParseException {
       Expression expr;
       Statement n = null;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -4260,7 +4260,7 @@ final class ASTParser implements ASTParserConstants {
       if (jj_2_39(2)) {
          expr = PreIncrementExpression();
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case DECR:
             expr = PreDecrementExpression();
             break;
@@ -4287,7 +4287,7 @@ final class ASTParser implements ASTParserConstants {
          case IDENTIFIER:
          case LPAREN:
             expr = PrimaryExpression();
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case ASSIGN:
             case INCR:
             case DECR:
@@ -4304,7 +4304,7 @@ final class ASTParser implements ASTParserConstants {
             case RUNSIGNEDSHIFTASSIGN:
             case ARROW:
             case DOUBLECOLON:
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case INCR:
                   jj_consume_token(INCR);
                   expr = new UnaryExpr(expr.getBeginLine(), expr.getBeginColumn(), token.endLine, token.endColumn,
@@ -4334,7 +4334,7 @@ final class ASTParser implements ASTParserConstants {
                   break;
                case DOUBLECOLON:
                   jj_consume_token(DOUBLECOLON);
-                  switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                  switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                   case LT:
                      typeArgs = TypeParameters();
                      typeArgs.remove(0);
@@ -4343,7 +4343,7 @@ final class ASTParser implements ASTParserConstants {
                      jj_la1[144] = jj_gen;
                      ;
                   }
-                  switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                  switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                   case IDENTIFIER:
                      jj_consume_token(IDENTIFIER);
                      break;
@@ -4407,7 +4407,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(RPAREN);
       jj_consume_token(LBRACE);
       label_64: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case CASE:
          case _DEFAULT:
             ;
@@ -4432,7 +4432,7 @@ final class ASTParser implements ASTParserConstants {
       List stmts;
       int line;
       int column;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case CASE:
          jj_consume_token(CASE);
          line = token.beginLine;
@@ -4471,7 +4471,7 @@ final class ASTParser implements ASTParserConstants {
       condition = Expression();
       jj_consume_token(RPAREN);
       thenStmt = Statement();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case ELSE:
          jj_consume_token(ELSE);
          elseStmt = Statement();
@@ -4545,7 +4545,7 @@ final class ASTParser implements ASTParserConstants {
          jj_consume_token(COLON);
          expr = Expression();
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case BOOLEAN:
          case BYTE:
@@ -4587,7 +4587,7 @@ final class ASTParser implements ASTParserConstants {
          case DECR:
          case PLUS:
          case MINUS:
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case ABSTRACT:
             case BOOLEAN:
             case BYTE:
@@ -4635,7 +4635,7 @@ final class ASTParser implements ASTParserConstants {
                ;
             }
             jj_consume_token(SEMICOLON);
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case BOOLEAN:
             case BYTE:
             case CHAR:
@@ -4671,7 +4671,7 @@ final class ASTParser implements ASTParserConstants {
                ;
             }
             jj_consume_token(SEMICOLON);
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case BOOLEAN:
             case BYTE:
             case CHAR:
@@ -4736,7 +4736,7 @@ final class ASTParser implements ASTParserConstants {
          ret = new LinkedList();
          ret.add(expr);
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case BOOLEAN:
          case BYTE:
          case CHAR:
@@ -4786,7 +4786,7 @@ final class ASTParser implements ASTParserConstants {
       expr = Expression();
       ret.add(expr);
       label_65: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -4822,7 +4822,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(BREAK);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IDENTIFIER:
          jj_consume_token(IDENTIFIER);
          id = token.image;
@@ -4846,7 +4846,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(CONTINUE);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IDENTIFIER:
          jj_consume_token(IDENTIFIER);
          id = token.image;
@@ -4870,7 +4870,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(RETURN);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -4966,7 +4966,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(TRY);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LPAREN:
          resources = ResourceSpecification();
          break;
@@ -4976,7 +4976,7 @@ final class ASTParser implements ASTParserConstants {
       }
       tryBlock = Block();
       label_66: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case CATCH:
             ;
             break;
@@ -4992,7 +4992,7 @@ final class ASTParser implements ASTParserConstants {
          exceptType = Type();
          exceptTypes.add(exceptType);
          label_67: while (true) {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case BIT_OR:
                ;
                break;
@@ -5011,7 +5011,7 @@ final class ASTParser implements ASTParserConstants {
                exceptModifier.annotations, exceptTypes, exceptId, catchBlock));
          exceptTypes = new LinkedList();
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case FINALLY:
          jj_consume_token(FINALLY);
          finallyBlock = Block();
@@ -5102,7 +5102,7 @@ final class ASTParser implements ASTParserConstants {
       } else if (jj_2_45(2147483647)) {
          ret = SingleMemberAnnotation();
       } else {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case AT:
             ret = MarkerAnnotation();
             break;
@@ -5129,7 +5129,7 @@ final class ASTParser implements ASTParserConstants {
       column = token.beginColumn;
       name = Name();
       jj_consume_token(LPAREN);
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IDENTIFIER:
          pairs = MemberValuePairs();
          break;
@@ -5185,7 +5185,7 @@ final class ASTParser implements ASTParserConstants {
       pair = MemberValuePair();
       ret.add(pair);
       label_69: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case COMMA:
             ;
             break;
@@ -5224,7 +5224,7 @@ final class ASTParser implements ASTParserConstants {
 
    final public Expression MemberValue() throws ParseException {
       Expression ret;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case AT:
          ret = Annotation();
          break;
@@ -5281,7 +5281,7 @@ final class ASTParser implements ASTParserConstants {
       jj_consume_token(LBRACE);
       line = token.beginLine;
       column = token.beginColumn;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -5329,7 +5329,7 @@ final class ASTParser implements ASTParserConstants {
          jj_la1[169] = jj_gen;
          ;
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case COMMA:
          jj_consume_token(COMMA);
          break;
@@ -5373,7 +5373,7 @@ final class ASTParser implements ASTParserConstants {
       BodyDeclaration member;
       jj_consume_token(LBRACE);
       label_71: while (true) {
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case ABSTRACT:
          case BOOLEAN:
          case BYTE:
@@ -5420,7 +5420,7 @@ final class ASTParser implements ASTParserConstants {
       Modifier modifier;
       BodyDeclaration ret;
       pushJavadoc();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case SEMICOLON:
          jj_consume_token(SEMICOLON);
          ret = new EmptyTypeDeclaration(token.beginLine, token.beginColumn, token.endLine, token.endColumn,
@@ -5454,7 +5454,7 @@ final class ASTParser implements ASTParserConstants {
          if (jj_2_47(2147483647)) {
             ret = AnnotationTypeMemberDeclaration(modifier);
          } else {
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case CLASS:
             case INTERFACE:
                ret = ClassOrInterfaceDeclaration(modifier);
@@ -5504,7 +5504,7 @@ final class ASTParser implements ASTParserConstants {
       name = token.image;
       jj_consume_token(LPAREN);
       jj_consume_token(RPAREN);
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case _DEFAULT:
          defaultVal = DefaultValue();
          break;
@@ -10790,7 +10790,7 @@ final class ASTParser implements ASTParserConstants {
       if ((jj_nt = token.next) == null)
          return (jj_ntk = (token.next = token_source.getNextToken()).kind);
       else
-         return (jj_ntk = jj_nt.kind);
+         return jj_ntk = jj_nt.kind;
    }
 
    private java.util.List<int[]> jj_expentries = new java.util.ArrayList<int[]>();
@@ -10810,7 +10810,7 @@ final class ASTParser implements ASTParserConstants {
             jj_expentry[i] = jj_lasttokens[i];
          }
          jj_entries_loop: for (java.util.Iterator<?> it = jj_expentries.iterator(); it.hasNext();) {
-            int[] oldentry = (int[]) (it.next());
+            int[] oldentry = (int[]) it.next();
             if (oldentry.length == jj_expentry.length) {
                for (int i = 0; i < jj_expentry.length; i++) {
                   if (oldentry[i] != jj_expentry[i]) {

--- a/src/main/java/org/walkmod/javalang/actions/Action.java
+++ b/src/main/java/org/walkmod/javalang/actions/Action.java
@@ -67,11 +67,11 @@ public abstract class Action {
 
    public boolean contains(Action action) {
 
-      if ((getBeginLine() < action.getBeginLine())
-            || ((getBeginLine() == action.getBeginLine()) && getBeginColumn() <= action.getBeginColumn())) {
+      if (getBeginLine() < action.getBeginLine()
+            || getBeginLine() == action.getBeginLine() && getBeginColumn() <= action.getBeginColumn()) {
          if (getEndLine() > action.getEndLine()) {
             return true;
-         } else if ((getEndLine() == action.getEndLine()) && getEndColumn() >= action.getEndColumn()) {
+         } else if (getEndLine() == action.getEndLine() && getEndColumn() >= action.getEndColumn()) {
             return true;
          }
       }

--- a/src/main/java/org/walkmod/javalang/javadoclinks/JavadocLinkParser.java
+++ b/src/main/java/org/walkmod/javalang/javadoclinks/JavadocLinkParser.java
@@ -61,7 +61,7 @@ public class JavadocLinkParser implements JavadocLinkParserConstants {
     String methodName = "";
     String aux = "";
     List<String> params = new LinkedList<String>();
-    switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+    switch (jj_ntk==-1 ?jj_ntk():jj_ntk) {
     case IDENTIFIER:
       className = type();
       break;
@@ -73,13 +73,13 @@ public class JavadocLinkParser implements JavadocLinkParserConstants {
     jj_consume_token(IDENTIFIER);
                                                     methodName = token.image;
     jj_consume_token(OPENPAR);
-    switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+    switch (jj_ntk==-1 ?jj_ntk():jj_ntk) {
     case IDENTIFIER:
       aux = type();
                                                                                                        params.add(aux);
       label_1:
       while (true) {
-        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+        switch (jj_ntk==-1 ?jj_ntk():jj_ntk) {
         case COMMA:
           ;
           break;
@@ -105,7 +105,7 @@ public class JavadocLinkParser implements JavadocLinkParserConstants {
   final public FieldLink fieldlink() throws ParseException {
     String className = "";
     String fieldName = "";
-    switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+    switch (jj_ntk==-1 ?jj_ntk():jj_ntk) {
     case IDENTIFIER:
       className = type();
       break;
@@ -127,7 +127,7 @@ public class JavadocLinkParser implements JavadocLinkParserConstants {
                   typeName = token.image;
     label_2:
     while (true) {
-      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+      switch (jj_ntk==-1 ?jj_ntk():jj_ntk) {
       case DOT:
         ;
         break;

--- a/src/main/java/org/walkmod/javalang/tags/TagsParser.java
+++ b/src/main/java/org/walkmod/javalang/tags/TagsParser.java
@@ -37,7 +37,7 @@ public class TagsParser implements TagsParserConstants {
 
    final public List<JavadocTag> javadoc() throws ParseException {
       List<JavadocTag> result = new LinkedList();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case PARAM:
       case RETURN:
       case THROWS:
@@ -72,7 +72,7 @@ public class TagsParser implements TagsParserConstants {
    }
 
    final public String inlineTag() throws ParseException {
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case CODE:
          jj_consume_token(CODE);
          break;
@@ -98,7 +98,7 @@ public class TagsParser implements TagsParserConstants {
    }
 
    final public String blockTag() throws ParseException {
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case AUTHOR:
          jj_consume_token(AUTHOR);
          break;
@@ -127,7 +127,7 @@ public class TagsParser implements TagsParserConstants {
    }
 
    final public String IDBlockTag() throws ParseException {
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case PARAM:
          jj_consume_token(PARAM);
          break;
@@ -153,7 +153,7 @@ public class TagsParser implements TagsParserConstants {
    }
 
    final public String NSInlineTag() throws ParseException {
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LINK:
          jj_consume_token(LINK);
          break;
@@ -177,7 +177,7 @@ public class TagsParser implements TagsParserConstants {
 
    final public String anyTag() throws ParseException {
       String result = "";
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case INHERITDOC:
       case DOCROOT:
       case CODE:
@@ -218,10 +218,10 @@ public class TagsParser implements TagsParserConstants {
       String result = "";
       String arg1 = null;
       String arg2 = null;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case OPENBRACE:
          jj_consume_token(OPENBRACE);
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LINKPLAIN:
          case LINK:
          case VALUE:
@@ -236,7 +236,7 @@ public class TagsParser implements TagsParserConstants {
             jj_la1[6] = jj_gen;
             ;
          }
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -269,7 +269,7 @@ public class TagsParser implements TagsParserConstants {
       case NAMECHAR:
       case OPERATION:
       case WORD:
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case WORD:
             jj_consume_token(WORD);
             break;
@@ -294,7 +294,7 @@ public class TagsParser implements TagsParserConstants {
             throw new ParseException();
          }
          arg1 = token.image;
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -361,13 +361,13 @@ public class TagsParser implements TagsParserConstants {
       JavadocTag result = null;
       List<String> values = null;
       String words = null;
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case INHERITDOC:
       case DOCROOT:
       case CODE:
       case LITERAL:
          tag = inlineTag();
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LINKPLAIN:
          case LINK:
          case VALUE:
@@ -401,19 +401,19 @@ public class TagsParser implements TagsParserConstants {
       case LINK:
       case VALUE:
          tag = NSInlineTag();
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case OPENBRACE:
          case ASTERISK:
          case IDENTIFIER:
          case NAMECHAR:
          case OPERATION:
          case WORD:
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
             case NAMECHAR:
             case OPERATION:
                ns = namespace();
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LINKPLAIN:
                case LINK:
                case VALUE:
@@ -492,7 +492,7 @@ public class TagsParser implements TagsParserConstants {
    }
 
    final public String namespace() throws ParseException {
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case IDENTIFIER:
          jj_consume_token(IDENTIFIER);
          break;
@@ -524,14 +524,14 @@ public class TagsParser implements TagsParserConstants {
       JavadocTag tag2 = null;
       List<String> values = null;
       List<JavadocTag> postTags = new LinkedList<JavadocTag>();
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case SERIALDATA:
       case DEPRECATED:
       case AUTHOR:
       case SINCE:
       case VERSION:
          name = blockTag();
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -561,7 +561,7 @@ public class TagsParser implements TagsParserConstants {
       case SERIAL:
          jj_consume_token(SERIAL);
          name = token.image;
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -580,12 +580,12 @@ public class TagsParser implements TagsParserConstants {
          case NAMECHAR:
          case OPERATION:
          case WORD:
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
             case NAMECHAR:
             case OPERATION:
                arg1 = namespace();
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -614,7 +614,7 @@ public class TagsParser implements TagsParserConstants {
                break;
             case ASTERISK:
             case WORD:
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case WORD:
                   jj_consume_token(WORD);
                   break;
@@ -627,7 +627,7 @@ public class TagsParser implements TagsParserConstants {
                   jj_consume_token(-1);
                   throw new ParseException();
                }
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -659,7 +659,7 @@ public class TagsParser implements TagsParserConstants {
                break;
             case OPENBRACE:
                jj_consume_token(OPENBRACE);
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LINKPLAIN:
                case LINK:
                case VALUE:
@@ -673,7 +673,7 @@ public class TagsParser implements TagsParserConstants {
                   jj_la1[21] = jj_gen;
                   ;
                }
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -733,7 +733,7 @@ public class TagsParser implements TagsParserConstants {
       case THROWS:
       case EXCEPTION:
          name = IDBlockTag();
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -752,11 +752,11 @@ public class TagsParser implements TagsParserConstants {
          case NAMECHAR:
          case OPERATION:
          case WORD:
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
                jj_consume_token(IDENTIFIER);
                arg1 = token.image;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -787,7 +787,7 @@ public class TagsParser implements TagsParserConstants {
             case NAMECHAR:
             case OPERATION:
             case WORD:
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case WORD:
                   jj_consume_token(WORD);
                   break;
@@ -806,7 +806,7 @@ public class TagsParser implements TagsParserConstants {
                   throw new ParseException();
                }
                arg1 = token.image;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -838,7 +838,7 @@ public class TagsParser implements TagsParserConstants {
                break;
             case OPENBRACE:
                jj_consume_token(OPENBRACE);
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LINKPLAIN:
                case LINK:
                case VALUE:
@@ -852,7 +852,7 @@ public class TagsParser implements TagsParserConstants {
                   jj_la1[28] = jj_gen;
                   ;
                }
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -912,7 +912,7 @@ public class TagsParser implements TagsParserConstants {
       case SERIALFIELD:
          jj_consume_token(SERIALFIELD);
          name = token.image;
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -928,11 +928,11 @@ public class TagsParser implements TagsParserConstants {
          case OPENBRACE:
          case IDENTIFIER:
          case NAMECHAR:
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case NAMECHAR:
                jj_consume_token(NAMECHAR);
                arg1 = token.image;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -951,11 +951,11 @@ public class TagsParser implements TagsParserConstants {
                case NAMECHAR:
                case OPERATION:
                case WORD:
-                  switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                  switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                   case IDENTIFIER:
                      jj_consume_token(IDENTIFIER);
                      arg2 = token.image;
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case PARAM:
                      case RETURN:
                      case THROWS:
@@ -986,7 +986,7 @@ public class TagsParser implements TagsParserConstants {
                   case NAMECHAR:
                   case OPERATION:
                   case WORD:
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case WORD:
                         jj_consume_token(WORD);
                         break;
@@ -1005,7 +1005,7 @@ public class TagsParser implements TagsParserConstants {
                         throw new ParseException();
                      }
                      arg2 = token.image;
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case PARAM:
                      case RETURN:
                      case THROWS:
@@ -1037,7 +1037,7 @@ public class TagsParser implements TagsParserConstants {
                      break;
                   case OPENBRACE:
                      jj_consume_token(OPENBRACE);
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case LINKPLAIN:
                      case LINK:
                      case VALUE:
@@ -1051,7 +1051,7 @@ public class TagsParser implements TagsParserConstants {
                         jj_la1[35] = jj_gen;
                         ;
                      }
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case PARAM:
                      case RETURN:
                      case THROWS:
@@ -1106,7 +1106,7 @@ public class TagsParser implements TagsParserConstants {
             case IDENTIFIER:
                jj_consume_token(IDENTIFIER);
                arg1 = token.image;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -1125,11 +1125,11 @@ public class TagsParser implements TagsParserConstants {
                case NAMECHAR:
                case OPERATION:
                case WORD:
-                  switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                  switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                   case IDENTIFIER:
                      jj_consume_token(IDENTIFIER);
                      arg2 = token.image;
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case PARAM:
                      case RETURN:
                      case THROWS:
@@ -1160,7 +1160,7 @@ public class TagsParser implements TagsParserConstants {
                   case NAMECHAR:
                   case OPERATION:
                   case WORD:
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case WORD:
                         jj_consume_token(WORD);
                         break;
@@ -1179,7 +1179,7 @@ public class TagsParser implements TagsParserConstants {
                         throw new ParseException();
                      }
                      arg2 = token.image;
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case PARAM:
                      case RETURN:
                      case THROWS:
@@ -1211,7 +1211,7 @@ public class TagsParser implements TagsParserConstants {
                      break;
                   case OPENBRACE:
                      jj_consume_token(OPENBRACE);
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case LINKPLAIN:
                      case LINK:
                      case VALUE:
@@ -1225,7 +1225,7 @@ public class TagsParser implements TagsParserConstants {
                         jj_la1[42] = jj_gen;
                         ;
                      }
-                     switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+                     switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                      case PARAM:
                      case RETURN:
                      case THROWS:
@@ -1284,7 +1284,7 @@ public class TagsParser implements TagsParserConstants {
                break;
             case OPENBRACE:
                jj_consume_token(OPENBRACE);
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LINKPLAIN:
                case LINK:
                case VALUE:
@@ -1298,7 +1298,7 @@ public class TagsParser implements TagsParserConstants {
                   jj_la1[46] = jj_gen;
                   ;
                }
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -1353,7 +1353,7 @@ public class TagsParser implements TagsParserConstants {
       case SEE:
          jj_consume_token(SEE);
          name = token.image;
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case PARAM:
          case RETURN:
          case THROWS:
@@ -1373,12 +1373,12 @@ public class TagsParser implements TagsParserConstants {
          case NAMECHAR:
          case OPERATION:
          case WORD:
-            switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+            switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
             case IDENTIFIER:
             case NAMECHAR:
             case OPERATION:
                arg1 = namespace();
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -1408,7 +1408,7 @@ public class TagsParser implements TagsParserConstants {
             case CLOSEBRACE:
             case ASTERISK:
             case WORD:
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case WORD:
                   jj_consume_token(WORD);
                   break;
@@ -1424,7 +1424,7 @@ public class TagsParser implements TagsParserConstants {
                   throw new ParseException();
                }
                arg2 = token.image;
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -1456,7 +1456,7 @@ public class TagsParser implements TagsParserConstants {
                break;
             case OPENBRACE:
                jj_consume_token(OPENBRACE);
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case LINKPLAIN:
                case LINK:
                case VALUE:
@@ -1475,7 +1475,7 @@ public class TagsParser implements TagsParserConstants {
                   jj_la1[53] = jj_gen;
                   ;
                }
-               switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+               switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
                case PARAM:
                case RETURN:
                case THROWS:
@@ -1559,7 +1559,7 @@ public class TagsParser implements TagsParserConstants {
    final public String inlineDescription() throws ParseException {
       String result = "";
       String w = "";
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LINKPLAIN:
       case LINK:
       case VALUE:
@@ -1585,7 +1585,7 @@ public class TagsParser implements TagsParserConstants {
          break;
       case OPENBRACE:
          jj_consume_token(OPENBRACE);
-         switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+         switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
          case LINKPLAIN:
          case LINK:
          case VALUE:
@@ -1622,7 +1622,7 @@ public class TagsParser implements TagsParserConstants {
          jj_consume_token(-1);
          throw new ParseException();
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LINKPLAIN:
       case LINK:
       case VALUE:
@@ -1664,7 +1664,7 @@ public class TagsParser implements TagsParserConstants {
    final public String textDescription() throws ParseException {
       String result = "";
       String w = "";
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case WORD:
          jj_consume_token(WORD);
          result = token.image;
@@ -1718,7 +1718,7 @@ public class TagsParser implements TagsParserConstants {
    final public String NSInlineDescription() throws ParseException {
       String result = "";
       String w = "";
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case WORD:
          jj_consume_token(WORD);
          result = token.image;
@@ -1736,7 +1736,7 @@ public class TagsParser implements TagsParserConstants {
          jj_consume_token(-1);
          throw new ParseException();
       }
-      switch ((jj_ntk == -1) ? jj_ntk() : jj_ntk) {
+      switch (jj_ntk == -1 ? jj_ntk() : jj_ntk) {
       case LINKPLAIN:
       case LINK:
       case VALUE:


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “  Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
