### PR TITLE
ScopeAware - logic fixes - maybe not ready for merge, please review

### DIFF
--- a/src/main/java/org/walkmod/javalang/ast/ScopeAwareUtil.java
+++ b/src/main/java/org/walkmod/javalang/ast/ScopeAwareUtil.java
@@ -1,0 +1,109 @@
+package org.walkmod.javalang.ast;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Common implementations of {@link ScopeAware} methods for delegation.
+ */
+public class ScopeAwareUtil {
+    private ScopeAwareUtil() {}
+
+    public static Map<String, SymbolDefinition> getVariableDefinitions(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null && (parent instanceof ScopeAware)) {
+            return ((ScopeAware) parent).getVariableDefinitions();
+        }
+        return new HashMap<String, SymbolDefinition>();
+    }
+
+    public static Map<String, SymbolDefinition> getVariableDefinitions2(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null) {
+            return ((ScopeAware) parent).getVariableDefinitions();
+        }
+        return new HashMap<String, SymbolDefinition>();
+    }
+
+    public static Map<String, SymbolDefinition> getVariableDefinitions3(Node n) {
+        Node parent = n.getParentNode();
+        Map<String, SymbolDefinition> result = null;
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null && (parent instanceof ScopeAware)) {
+            result = ((ScopeAware) parent).getVariableDefinitions();
+        }
+        if (result == null) {
+            result = new HashMap<String, SymbolDefinition>();
+        }
+        return result;
+    }
+
+    public static ScopeAware findParentScope(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && !(parent instanceof ScopeAware)) {
+            parent = parent.getParentNode();
+        }
+        return parent != null ? (ScopeAware) parent : null;
+    }
+
+    public static ScopeAware findParentScope2(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        return parent != null ? (ScopeAware) parent : null;
+    }
+
+    public static Map<String, List<SymbolDefinition>> getMethodDefinitions(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null && (parent instanceof ScopeAware)) {
+            return ((ScopeAware) parent).getMethodDefinitions();
+        }
+        return new HashMap<String, List<SymbolDefinition>>();
+    }
+
+    public static Map<String, List<SymbolDefinition>> getMethodDefinitions2(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null) {
+            return ((ScopeAware) parent).getMethodDefinitions();
+        }
+        return new HashMap<String, List<SymbolDefinition>>();
+    }
+
+    public static Map<String, SymbolDefinition> getTypeDefinitions(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null && (parent instanceof ScopeAware)) {
+            return ((ScopeAware) parent).getTypeDefinitions();
+        }
+        return new HashMap<String, SymbolDefinition>();
+    }
+
+    public static Map<String, SymbolDefinition> getTypeDefinitions2(Node n) {
+        Node parent = n.getParentNode();
+        while (parent != null && parent instanceof ScopeAware) {
+            parent = parent.getParentNode();
+        }
+        if (parent != null) {
+            return ((ScopeAware) parent).getTypeDefinitions();
+        }
+        return new HashMap<String, SymbolDefinition>();
+    }
+}

--- a/src/main/java/org/walkmod/javalang/ast/ScopeAwareUtil.java
+++ b/src/main/java/org/walkmod/javalang/ast/ScopeAwareUtil.java
@@ -10,43 +10,6 @@ import java.util.Map;
 public class ScopeAwareUtil {
     private ScopeAwareUtil() {}
 
-    public static Map<String, SymbolDefinition> getVariableDefinitions(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
-    }
-
-    public static Map<String, SymbolDefinition> getVariableDefinitions2(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
-    }
-
-    public static Map<String, SymbolDefinition> getVariableDefinitions3(Node n) {
-        Node parent = n.getParentNode();
-        Map<String, SymbolDefinition> result = null;
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            result = ((ScopeAware) parent).getVariableDefinitions();
-        }
-        if (result == null) {
-            result = new HashMap<String, SymbolDefinition>();
-        }
-        return result;
-    }
-
     public static ScopeAware findParentScope(Node n) {
         Node parent = n.getParentNode();
         while (parent != null && !(parent instanceof ScopeAware)) {
@@ -55,55 +18,18 @@ public class ScopeAwareUtil {
         return parent != null ? (ScopeAware) parent : null;
     }
 
-    public static ScopeAware findParentScope2(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        return parent != null ? (ScopeAware) parent : null;
+    public static Map<String, SymbolDefinition> getVariableDefinitions(Node n) {
+        final ScopeAware scope = findParentScope(n);
+        return scope != null ? scope.getVariableDefinitions() : new HashMap<String, SymbolDefinition>();
     }
 
     public static Map<String, List<SymbolDefinition>> getMethodDefinitions(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
-    }
-
-    public static Map<String, List<SymbolDefinition>> getMethodDefinitions2(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        final ScopeAware scope = findParentScope(n);
+        return scope != null ? scope.getMethodDefinitions() : new HashMap<String, List<SymbolDefinition>>();
     }
 
     public static Map<String, SymbolDefinition> getTypeDefinitions(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
-    }
-
-    public static Map<String, SymbolDefinition> getTypeDefinitions2(Node n) {
-        Node parent = n.getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        final ScopeAware scope = findParentScope(n);
+        return scope != null ? scope.getTypeDefinitions() : new HashMap<String, SymbolDefinition>();
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/TypeParameter.java
+++ b/src/main/java/org/walkmod/javalang/ast/TypeParameter.java
@@ -14,7 +14,6 @@
  */
 package org.walkmod.javalang.ast;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -253,38 +252,17 @@ public final class TypeParameter extends Node implements SymbolDefinition {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions2(this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions2(this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions2(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/TypeParameter.java
+++ b/src/main/java/org/walkmod/javalang/ast/TypeParameter.java
@@ -252,17 +252,17 @@ public final class TypeParameter extends Node implements SymbolDefinition {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions2(this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        return ScopeAwareUtil.getMethodDefinitions2(this);
+        return ScopeAwareUtil.getMethodDefinitions(this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        return ScopeAwareUtil.getTypeDefinitions2(this);
+        return ScopeAwareUtil.getTypeDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/body/BaseParameter.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/BaseParameter.java
@@ -14,13 +14,12 @@
  */
 package org.walkmod.javalang.ast.body;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolData;
 import org.walkmod.javalang.ast.SymbolDataAware;
 import org.walkmod.javalang.ast.SymbolDefinition;
@@ -213,38 +212,17 @@ public abstract class BaseParameter extends Node implements SymbolDataAware<Symb
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(BaseParameter.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(BaseParameter.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/body/BaseParameter.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/BaseParameter.java
@@ -212,7 +212,7 @@ public abstract class BaseParameter extends Node implements SymbolDataAware<Symb
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(BaseParameter.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/body/BodyDeclaration.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/BodyDeclaration.java
@@ -14,7 +14,6 @@
  */
 package org.walkmod.javalang.ast.body;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +131,7 @@ public abstract class BodyDeclaration extends Node implements ScopeAware {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(BodyDeclaration.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/body/BodyDeclaration.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/BodyDeclaration.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.expr.AnnotationExpr;
 import org.walkmod.merger.MergeEngine;
@@ -131,37 +132,16 @@ public abstract class BodyDeclaration extends Node implements ScopeAware {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(BodyDeclaration.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(BodyDeclaration.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(BodyDeclaration.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/body/JavadocTag.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/JavadocTag.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.visitors.GenericVisitor;
@@ -117,37 +118,16 @@ public class JavadocTag extends Node implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(JavadocTag.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(JavadocTag.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(JavadocTag.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/body/JavadocTag.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/JavadocTag.java
@@ -14,13 +14,11 @@
  */
 package org.walkmod.javalang.ast.body;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -118,7 +116,7 @@ public class JavadocTag extends Node implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(JavadocTag.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/body/TypeDeclaration.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/TypeDeclaration.java
@@ -238,7 +238,7 @@ public abstract class TypeDeclaration extends BodyDeclaration
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        final ScopeAware scope = ScopeAwareUtil.findParentScope2(this);
+        final ScopeAware scope = ScopeAwareUtil.findParentScope(this);
         if (scope != null) {
             Map<String, List<SymbolDefinition>> aux = scope.getMethodDefinitions();
             List<BodyDeclaration> children = getMembers();
@@ -292,7 +292,7 @@ public abstract class TypeDeclaration extends BodyDeclaration
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        final ScopeAware scope = ScopeAwareUtil.findParentScope2(this);
+        final ScopeAware scope = ScopeAwareUtil.findParentScope(this);
         if (scope != null) {
             Map<String, SymbolDefinition> aux = scope.getVariableDefinitions();
             List<BodyDeclaration> children = getMembers();

--- a/src/main/java/org/walkmod/javalang/ast/body/TypeDeclaration.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/TypeDeclaration.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolData;
 import org.walkmod.javalang.ast.SymbolDataAware;
 import org.walkmod.javalang.ast.SymbolDefinition;
@@ -237,12 +238,9 @@ public abstract class TypeDeclaration extends BodyDeclaration
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            Map<String, List<SymbolDefinition>> aux = ((ScopeAware) parent).getMethodDefinitions();
+        final ScopeAware scope = ScopeAwareUtil.findParentScope2(this);
+        if (scope != null) {
+            Map<String, List<SymbolDefinition>> aux = scope.getMethodDefinitions();
             List<BodyDeclaration> children = getMembers();
             if (children != null) {
                 for (BodyDeclaration child : children) {
@@ -264,12 +262,9 @@ public abstract class TypeDeclaration extends BodyDeclaration
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && !(parent instanceof ScopeAware)) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && parent instanceof ScopeAware) {
-            Map<String, SymbolDefinition> aux = ((ScopeAware) parent).getVariableDefinitions();
+        final ScopeAware scope = ScopeAwareUtil.findParentScope(this);
+        if (scope != null) {
+            Map<String, SymbolDefinition> aux = scope.getVariableDefinitions();
             List<BodyDeclaration> children = getMembers();
             if (children != null) {
                 for (BodyDeclaration child : children) {
@@ -297,12 +292,9 @@ public abstract class TypeDeclaration extends BodyDeclaration
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null) {
-            Map<String, SymbolDefinition> aux = ((ScopeAware) parent).getVariableDefinitions();
+        final ScopeAware scope = ScopeAwareUtil.findParentScope2(this);
+        if (scope != null) {
+            Map<String, SymbolDefinition> aux = scope.getVariableDefinitions();
             List<BodyDeclaration> children = getMembers();
             if (children != null) {
                 for (BodyDeclaration child : children) {

--- a/src/main/java/org/walkmod/javalang/ast/body/VariableDeclarator.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/VariableDeclarator.java
@@ -15,7 +15,6 @@
 package org.walkmod.javalang.ast.body;
 
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +22,6 @@ import java.util.Map;
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.Refactorizable;
 import org.walkmod.javalang.ast.Refactorization;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -238,7 +236,7 @@ public final class VariableDeclarator extends Node
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(VariableDeclarator.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/body/VariableDeclarator.java
+++ b/src/main/java/org/walkmod/javalang/ast/body/VariableDeclarator.java
@@ -24,6 +24,7 @@ import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.Refactorizable;
 import org.walkmod.javalang.ast.Refactorization;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.ast.expr.Expression;
@@ -237,38 +238,17 @@ public final class VariableDeclarator extends Node
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(VariableDeclarator.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(VariableDeclarator.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(VariableDeclarator.this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/FieldAccessExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/FieldAccessExpr.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.ast.type.Type;
@@ -178,37 +179,16 @@ public final class FieldAccessExpr extends Expression implements SymbolReference
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(FieldAccessExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(FieldAccessExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(FieldAccessExpr.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/FieldAccessExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/FieldAccessExpr.java
@@ -14,13 +14,11 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -179,7 +177,7 @@ public final class FieldAccessExpr extends Expression implements SymbolReference
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(FieldAccessExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/LambdaExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/LambdaExpr.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.ast.body.Parameter;
@@ -208,38 +209,17 @@ public class LambdaExpr extends Expression implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(LambdaExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(LambdaExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(LambdaExpr.this);
     }
 
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/LambdaExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/LambdaExpr.java
@@ -14,7 +14,6 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 
 /*
@@ -36,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -209,7 +207,7 @@ public class LambdaExpr extends Expression implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(LambdaExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/MarkerAnnotationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/MarkerAnnotationExpr.java
@@ -15,12 +15,9 @@
 
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.visitors.GenericVisitor;
@@ -70,7 +67,7 @@ public final class MarkerAnnotationExpr extends AnnotationExpr {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(MarkerAnnotationExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/MarkerAnnotationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/MarkerAnnotationExpr.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.visitors.GenericVisitor;
 import org.walkmod.javalang.visitors.VoidVisitor;
@@ -69,37 +70,16 @@ public final class MarkerAnnotationExpr extends AnnotationExpr {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(MarkerAnnotationExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(MarkerAnnotationExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(MarkerAnnotationExpr.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/MethodCallExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/MethodCallExpr.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.walkmod.javalang.ast.MethodSymbolData;
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.ast.type.Type;
@@ -225,37 +226,16 @@ public final class MethodCallExpr extends Expression implements SymbolReference 
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(MethodCallExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(MethodCallExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(MethodCallExpr.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/MethodCallExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/MethodCallExpr.java
@@ -14,14 +14,12 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.MethodSymbolData;
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -226,7 +224,7 @@ public final class MethodCallExpr extends Expression implements SymbolReference 
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(MethodCallExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/MethodReferenceExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/MethodReferenceExpr.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.walkmod.javalang.ast.MethodSymbolData;
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolData;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -212,37 +213,16 @@ public class MethodReferenceExpr extends Expression implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(MethodReferenceExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(MethodReferenceExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(MethodReferenceExpr.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/MethodReferenceExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/MethodReferenceExpr.java
@@ -14,14 +14,12 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.MethodSymbolData;
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolData;
 import org.walkmod.javalang.ast.SymbolDefinition;
@@ -213,7 +211,7 @@ public class MethodReferenceExpr extends Expression implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(MethodReferenceExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/NameExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/NameExpr.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.visitors.GenericVisitor;
@@ -101,38 +102,17 @@ public class NameExpr extends Expression implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(NameExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(NameExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(NameExpr.this);
     }
 
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/NameExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/NameExpr.java
@@ -14,13 +14,11 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -102,7 +100,7 @@ public class NameExpr extends Expression implements SymbolReference {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(NameExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/NormalAnnotationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/NormalAnnotationExpr.java
@@ -14,13 +14,11 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.visitors.GenericVisitor;
@@ -136,7 +134,7 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(NormalAnnotationExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/NormalAnnotationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/NormalAnnotationExpr.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.visitors.GenericVisitor;
 import org.walkmod.javalang.visitors.VoidVisitor;
@@ -135,38 +136,17 @@ public final class NormalAnnotationExpr extends AnnotationExpr {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(NormalAnnotationExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(NormalAnnotationExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(NormalAnnotationExpr.this);
     }
 
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/ObjectCreationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/ObjectCreationExpr.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.walkmod.javalang.ast.ConstructorSymbolData;
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.ast.body.BodyDeclaration;
@@ -337,38 +338,17 @@ public final class ObjectCreationExpr extends Expression implements SymbolRefere
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(ObjectCreationExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(ObjectCreationExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(ObjectCreationExpr.this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/ObjectCreationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/ObjectCreationExpr.java
@@ -14,14 +14,12 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.ConstructorSymbolData;
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -338,7 +336,7 @@ public final class ObjectCreationExpr extends Expression implements SymbolRefere
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(ObjectCreationExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/expr/SingleMemberAnnotationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/SingleMemberAnnotationExpr.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.visitors.GenericVisitor;
 import org.walkmod.javalang.visitors.VoidVisitor;
@@ -93,38 +94,17 @@ public final class SingleMemberAnnotationExpr extends AnnotationExpr {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(SingleMemberAnnotationExpr.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(SingleMemberAnnotationExpr.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(SingleMemberAnnotationExpr.this);
     }
 
 }

--- a/src/main/java/org/walkmod/javalang/ast/expr/SingleMemberAnnotationExpr.java
+++ b/src/main/java/org/walkmod/javalang/ast/expr/SingleMemberAnnotationExpr.java
@@ -14,12 +14,10 @@
  */
 package org.walkmod.javalang.ast.expr;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.visitors.GenericVisitor;
@@ -94,7 +92,7 @@ public final class SingleMemberAnnotationExpr extends AnnotationExpr {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(SingleMemberAnnotationExpr.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/stmt/BlockStmt.java
+++ b/src/main/java/org/walkmod/javalang/ast/stmt/BlockStmt.java
@@ -14,7 +14,6 @@
  */
 package org.walkmod.javalang.ast.stmt;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +116,7 @@ public final class BlockStmt extends Statement implements ScopeAware {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Map<String, SymbolDefinition> result = ScopeAwareUtil.getVariableDefinitions3(this);
+        Map<String, SymbolDefinition> result = ScopeAwareUtil.getVariableDefinitions(this);
         if (stmts != null) {
             for (Statement stmt : stmts) {
                 if (stmt instanceof ExpressionStmt) {

--- a/src/main/java/org/walkmod/javalang/ast/stmt/BlockStmt.java
+++ b/src/main/java/org/walkmod/javalang/ast/stmt/BlockStmt.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.body.VariableDeclarator;
 import org.walkmod.javalang.ast.expr.Expression;
@@ -116,17 +117,7 @@ public final class BlockStmt extends Statement implements ScopeAware {
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        Map<String, SymbolDefinition> result = null;
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            result = ((ScopeAware) parent).getVariableDefinitions();
-        }
-        if (result == null) {
-            result = new HashMap<String, SymbolDefinition>();
-        }
+        Map<String, SymbolDefinition> result = ScopeAwareUtil.getVariableDefinitions3(this);
         if (stmts != null) {
             for (Statement stmt : stmts) {
                 if (stmt instanceof ExpressionStmt) {
@@ -149,25 +140,11 @@ public final class BlockStmt extends Statement implements ScopeAware {
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(BlockStmt.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(BlockStmt.this);
     }
 }

--- a/src/main/java/org/walkmod/javalang/ast/stmt/TypeDeclarationStmt.java
+++ b/src/main/java/org/walkmod/javalang/ast/stmt/TypeDeclarationStmt.java
@@ -14,12 +14,10 @@
  */
 package org.walkmod.javalang.ast.stmt;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
@@ -154,7 +152,7 @@ public final class TypeDeclarationStmt extends Statement implements SymbolDefini
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(TypeDeclarationStmt.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/stmt/TypeDeclarationStmt.java
+++ b/src/main/java/org/walkmod/javalang/ast/stmt/TypeDeclarationStmt.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolDefinition;
 import org.walkmod.javalang.ast.SymbolReference;
 import org.walkmod.javalang.ast.body.TypeDeclaration;
@@ -153,38 +154,17 @@ public final class TypeDeclarationStmt extends Statement implements SymbolDefini
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(TypeDeclarationStmt.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(TypeDeclarationStmt.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(TypeDeclarationStmt.this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/type/Type.java
+++ b/src/main/java/org/walkmod/javalang/ast/type/Type.java
@@ -14,13 +14,11 @@
  */
 package org.walkmod.javalang.ast.type;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
-import org.walkmod.javalang.ast.ScopeAware;
 import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolData;
 import org.walkmod.javalang.ast.SymbolDataAware;
@@ -110,7 +108,7 @@ public abstract class Type extends Node implements SymbolDataAware<SymbolData>, 
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        return ScopeAwareUtil.getVariableDefinitions(Type.this);
+        return ScopeAwareUtil.getVariableDefinitions(this);
     }
 
     @Override

--- a/src/main/java/org/walkmod/javalang/ast/type/Type.java
+++ b/src/main/java/org/walkmod/javalang/ast/type/Type.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.walkmod.javalang.ast.Node;
 import org.walkmod.javalang.ast.ScopeAware;
+import org.walkmod.javalang.ast.ScopeAwareUtil;
 import org.walkmod.javalang.ast.SymbolData;
 import org.walkmod.javalang.ast.SymbolDataAware;
 import org.walkmod.javalang.ast.SymbolDefinition;
@@ -109,37 +110,16 @@ public abstract class Type extends Node implements SymbolDataAware<SymbolData>, 
 
     @Override
     public Map<String, SymbolDefinition> getVariableDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getVariableDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getVariableDefinitions(Type.this);
     }
 
     @Override
     public Map<String, List<SymbolDefinition>> getMethodDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getMethodDefinitions();
-        }
-        return new HashMap<String, List<SymbolDefinition>>();
+        return ScopeAwareUtil.getMethodDefinitions(Type.this);
     }
 
     @Override
     public Map<String, SymbolDefinition> getTypeDefinitions() {
-        Node parent = getParentNode();
-        while (parent != null && parent instanceof ScopeAware) {
-            parent = parent.getParentNode();
-        }
-        if (parent != null && (parent instanceof ScopeAware)) {
-            return ((ScopeAware) parent).getTypeDefinitions();
-        }
-        return new HashMap<String, SymbolDefinition>();
+        return ScopeAwareUtil.getTypeDefinitions(Type.this);
     }
 }


### PR DESCRIPTION
Moin Raquel!

The first step of the pull request is just extracting common code from the AST nodes.
I think a lot of the code is wrong but before fixing it I better ask about the direction.

As I understand it ALL the methods should use the next enclosing parent scope of the node as computed in findParentScope.

But most of the methods don't do that:
All getVariableDefinitions* miss a negation on the first loop condition, so never will find a scope.
The same is true for findParentScope2 and getMethodDefinitions* and getTypeDefinitions*.

IMHO all methods should use findParentScope but because most methods are wrong I wonder if this is
the correct solution.

And I also don't understand why a new HashMap is returned in the other cases.

I would either expect to 
a) to store the HashMap somewhere if it's important what is written into it
b) return an immutable Map to find locations where something is added to the Map which is wasted

Or is that because of some implementations of ScopeAware methods add to that Map on each call and should not create the HashMap on there own? Has a light smell of wrong responsibilities for me.

Have fun,
   Cal