### PR TITLE
Fixed getSimpleName method for package-info.java files

### DIFF
--- a/src/main/java/org/walkmod/javalang/ast/CompilationUnit.java
+++ b/src/main/java/org/walkmod/javalang/ast/CompilationUnit.java
@@ -348,11 +348,11 @@ public final class CompilationUnit extends Node implements Mergeable<Compilation
     }
 
     public String getSimpleName() {
-        String name = "";
         if (getTypes() != null) {
-            name = getTypes().get(0).getName();
+            return getTypes().get(0).getName();
+        } else {
+            return "package-info";
         }
-        return name;
     }
 
     @Override

--- a/src/test/java/org/walkmod/javalang/ast/CompilationUnitTest.java
+++ b/src/test/java/org/walkmod/javalang/ast/CompilationUnitTest.java
@@ -1,0 +1,31 @@
+package org.walkmod.javalang.ast;
+
+import org.junit.Test;
+import org.walkmod.javalang.ASTManager;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompilationUnitTest {
+
+  @Test
+  public void shouldReturnCorrectFilenameForClass() throws Exception {
+    final File packageInfoFile = new File(getClass().getClassLoader()
+        .getResource("test.txt").getFile());
+    final CompilationUnit cu = ASTManager.parse(packageInfoFile);
+
+    assertEquals("IntMath", cu.getSimpleName());
+    assertEquals("com/google/common/math/IntMath.java", cu.getFileName());
+  }
+
+  @Test
+  public void shouldReturnCorrectFilenameForPackageInfoFile() throws Exception {
+    final File packageInfoFile = new File(getClass().getClassLoader()
+        .getResource("package-info.txt").getFile());
+    final CompilationUnit cu = ASTManager.parse(packageInfoFile);
+
+    assertEquals("package-info", cu.getSimpleName());
+    assertEquals("com/example/hello/package-info.java", cu.getFileName());
+  }
+}

--- a/src/test/resources/package-info.txt
+++ b/src/test/resources/package-info.txt
@@ -1,0 +1,7 @@
+/**
+ * Common package comments :)
+ */
+@VisibleForTesting
+package com.example.hello;
+
+import com.google.common.annotations.VisibleForTesting;


### PR DESCRIPTION
package-info.java files do not contain types, thus return of empty
string breaks the `getFileName` name. The fix just returns the
`package-info` for `getSimpleName` if there are no types.